### PR TITLE
add etckeeper {pre,post}run_commands to generated puppet.conf

### DIFF
--- a/puppet-git-receiver-update-hook
+++ b/puppet-git-receiver-update-hook
@@ -149,11 +149,11 @@ mkdir -p $confdir/ssl
 
 cat <<EOF > "${confdir}/puppet.conf"
 [main]
-  node_terminus = exec
-  external_nodes = `pwd`/$0
-  templatedir=${DEST}/templates
-  prerun_command=/etc/puppet/etckeeper-commit-pre
-  postrun_command=/etc/puppet/etckeeper-commit-post
+  node_terminus   = exec
+  external_nodes  = `pwd`/$0
+  templatedir     = ${DEST}/templates
+  prerun_command  = /etc/puppet/etckeeper-commit-pre
+  postrun_command = /etc/puppet/etckeeper-commit-post
 EOF
 
 notice "Applying puppet manifests"


### PR DESCRIPTION
This allows automatic integration with the etckeeper system, if it is
present and configured.  AFAIK this is the easiest way available to track /etc
changes pre/post a puppet apply run; but even if not it's very common and
useful :)

The etckeeper scripts are supplied (and enabled by default) by the ubuntu
puppet-common package.
