### PR TITLE
Install modules with librarian-puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ precedence.
 
 Puppet version 2.7.12 is required for installing forge modules.
 
+## Librarian-puppet integration
+
+puppet-git-receiver can alternatively download and install modules using
+librarian-puppet. If a `Puppetfile` is found in your repository and
+librarian-puppet is installed the modules will be fetched before applying your
+manifests.
+
+Options to librarian-puppet can be supplied by setting the
+`puppet-receiver.librarian-puppet-args` git config option on the remote
+repository:
+
+    git config --add puppet-receiver.librarian-puppet-args "--verbose"
+
 ## Yaml-based node classification
 
 You can classify nodes using yaml files placed in the `manifests/`

--- a/puppet-git-receiver-update-hook
+++ b/puppet-git-receiver-update-hook
@@ -118,6 +118,15 @@ if [ -e $pf_file ] ; then
 		module_path="$module_path:$pf_path"
 fi
 
+if [ -e "${DEST}/Puppetfile" ] ; then
+	if ! which librarian-puppet >/dev/null ; then
+		error 'Puppetfile found in repo but librarian-puppet not installed.'
+	else
+		notice "Installing librarian-puppet modules"
+		lp_options=$(git config puppet-receiver.librarian-puppet-args)
+		(cd $DEST; librarian-puppet install $lp_options)
+	fi
+fi
 
 manifest_file="${DEST}/manifests/site.pp"
 


### PR DESCRIPTION
This addresses issue #6 and also your comment in pull request #11. If a Puppetfile is found in the repo it checks if the librarian-puppet command is available and if so uses it to install the modules.
